### PR TITLE
Fix for error when using sn3218 2.0.0

### DIFF
--- a/library/setup.cfg
+++ b/library/setup.cfg
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 [metadata]
 name = trilobot
-version = 0.0.1
+version = 0.0.2
 author = Christopher Parrott
 author_email = chris@pimoroni.com
 description = Trilobot, a mid-level robot learning platform aimed at the Rasberry Pi SBC range
@@ -30,7 +30,7 @@ classifiers =
 python_requires = >= 2.7
 packages = trilobot
 install_requires =
-	sn3218
+	sn3218>=2.0.0
 	evdev
 
 [flake8]

--- a/library/trilobot/__init__.py
+++ b/library/trilobot/__init__.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python3
 
 import time
-import sn3218
+try:
+    from sn3218 import SN3218
+except ImportError:
+    import sn3218
 import RPi.GPIO as GPIO
 from colorsys import hsv_to_rgb
 
-__version__ = '0.0.1'
+__version__ = '0.0.2'
 
 BUTTON_A = 0
 BUTTON_B = 1
@@ -130,12 +133,17 @@ class Trilobot():
                                   self.MOTOR_RIGHT_P: motor_right_p_pwm,
                                   self.MOTOR_RIGHT_N: motor_right_n_pwm}
 
-        sn3218.reset()
+        try:
+            self.sn3218 = SN3218()
+        except NameError:
+            self.sn3218 = sn3218
+
+        self.sn3218.reset()
 
         self.underlight = [0 for i in range(18)]
-        sn3218.output(self.underlight)
-        sn3218.enable_leds(0b111111111111111111)
-        sn3218.disable()
+        self.sn3218.output(self.underlight)
+        self.sn3218.enable_leds(0b111111111111111111)
+        self.sn3218.disable()
 
         # setup ultrasonic sensor pins
         GPIO.setup(self.ULTRA_TRIG_PIN, GPIO.OUT)
@@ -147,7 +155,7 @@ class Trilobot():
     def __del__(self):
         """ Clean up GPIO and underlighting when the class is deleted.
         """
-        sn3218.disable()
+        self.sn3218.disable()
         GPIO.cleanup()
 
     ###########
@@ -328,13 +336,13 @@ class Trilobot():
     def show_underlighting(self):
         """ Shows the previously stored colors on Trilobot's underlights.
         """
-        sn3218.output(self.underlight)
-        sn3218.enable()
+        self.sn3218.output(self.underlight)
+        self.sn3218.enable()
 
     def disable_underlighting(self):
         """ Disables Trilobot's underlighting, preserving the last set colors.
         """
-        sn3218.disable()
+        self.sn3218.disable()
 
     def set_underlight(self, light, r_color, g=None, b=None, show=True):
         """ Sets a single underlight to a given RGB color.

--- a/library/trilobot/__init__.py
+++ b/library/trilobot/__init__.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python3
 
 import time
-try:
-    from sn3218 import SN3218
-except ImportError:
-    import sn3218
+import sn3218
 import RPi.GPIO as GPIO
 from colorsys import hsv_to_rgb
 
@@ -134,7 +131,7 @@ class Trilobot():
                                   self.MOTOR_RIGHT_N: motor_right_n_pwm}
 
         try:
-            self.sn3218 = SN3218()
+            self.sn3218 = sn3218.SN3218()
         except NameError:
             self.sn3218 = sn3218
 


### PR DESCRIPTION
Fixed an issue caused by the 2.0.0 version of SN3218 upgrading to a class, but only wrapping some of the functions as module calls. Now this code checks for if a class is available and uses that, otherwise reverts to the module calls, as these work for 1.2.7.