### PR TITLE
Add PS5 DualSense support

### DIFF
--- a/library/trilobot/controller_mappings.py
+++ b/library/trilobot/controller_mappings.py
@@ -268,6 +268,56 @@ def create_ps4_wireless_controller_motion():
     return controller
 
 
+def create_ps5_wireless_controller(stick_deadzone_percent=0.1):
+    """ Create a controller class for the PlayStation 5 DualSense controller.
+    stick_deadzone_percent: the deadzone amount to apply to the controller's analog sticks
+    """
+    controller = SimpleController("DualSense Wireless Controller", exact_match=True)
+
+    # Button and axis registrations for PS4 Controller
+    controller.register_button("Cross", 304, alt_name="A")
+    controller.register_button("Circle", 305, alt_name="B")
+    controller.register_button("Square", 308, alt_name="X")
+    controller.register_button("Triangle", 307, alt_name="Y")
+    controller.register_button("Options", 315, alt_name='Start')
+    controller.register_button("Share", 314, alt_name='Select')
+    controller.register_button("PS", 316, alt_name='Home')
+    controller.register_button("L1", 310, alt_name="LB")
+    controller.register_button("L2", 312, alt_name="LT")
+    controller.register_button("R1", 311, alt_name="RB")
+    controller.register_button("R2", 313, alt_name="RT")
+    controller.register_axis_as_button("Left", 16, -1, 0)
+    controller.register_axis_as_button("Right", 16, 1, 0)
+    controller.register_axis_as_button("Up", 17, -1, 0)
+    controller.register_axis_as_button("Down", 17, 1, 0)
+    controller.register_button("L3", 317, alt_name='LS')
+    controller.register_button("R3", 318, alt_name='RS')
+
+    controller.register_axis("LX", 0, 0, 255, deadzone_percent=stick_deadzone_percent)
+    controller.register_axis("LY", 1, 0, 255, deadzone_percent=stick_deadzone_percent)
+    controller.register_axis("RX", 3, 0, 255, deadzone_percent=stick_deadzone_percent)
+    controller.register_axis("RY", 4, 0, 255, deadzone_percent=stick_deadzone_percent)
+    controller.register_trigger_axis("L2", 2, 0, 255, alt_name="LT")
+    controller.register_trigger_axis("R2", 5, 0, 255, alt_name="RT")
+    return controller
+
+
+def create_ps5_wireless_controller_motion():
+    """ Create a controller class for the PlayStation 5 DualSense controller's motion sensors.
+    """
+    controller = SimpleController("DualSense Wireless Controller Motion Sensors", exact_match=True)
+
+    # Button and axis registrations for PS4 Controller Motion
+    controller.register_axis("X", 0, 8500, -8500, alt_name="LX")
+    controller.register_axis("Y", 1, 8500, -8500, alt_name="LY")
+    controller.register_axis("Z", 2, -8500, 8500)
+    controller.register_axis("RX", 3, -8500, 8500)
+    controller.register_axis("RY", 4, -8500, 8500)
+    controller.register_axis("RZ", 5, -8500, 8500)
+
+    return controller
+
+
 def choose_controller():
     """ Present the user with a selection menu for pre-configured controllers.
     """
@@ -279,9 +329,13 @@ def choose_controller():
                        ("Xbox One Wireless Receiver", create_xbox_one_wireless_controller),
                        ("PS4 Controller", create_ps4_wireless_controller),
                        ("PS4 Controller - Touchpad", create_ps4_wireless_controller_touchpad),
-                       ("PS4 Controller - Motion Sensors", create_ps4_wireless_controller_motion)]
+                       ("PS4 Controller - Motion Sensors", create_ps4_wireless_controller_motion),
+                       ("DualSense Wireless Controller", create_ps5_wireless_controller),
+                       ("DualSense Wireless Controller Motion Sensors", create_ps5_wireless_controller_motion),
+                       ]
 
     print("Currently supported controllers:")
+
     for i in range(0, len(controller_list)):
         print("  ", i, ") ", controller_list[i][0], sep="")
 


### PR DESCRIPTION
Add PS5 dualsense support.
Mappings remain the same as the PS4 Wireless Controller, but with correct controller names for the DualSense.